### PR TITLE
bump min version of bootstrap-ie8 to 4.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "body-parser": "^1.19.0",
     "bootstrap": "^4.1.3",
     "bootstrap-datepicker": "^1.8.0",
-    "bootstrap-ie8": "^4.1.3",
+    "bootstrap-ie8": "^4.3.1",
     "brace": "^0.11.1",
     "busboy": "^0.3.0",
     "chart.js": "^2.7.2",


### PR DESCRIPTION
REF: https://github.com/coliff/bootstrap-ie8/releases